### PR TITLE
Initialize UI

### DIFF
--- a/source/editor/editor.cmajorpatch
+++ b/source/editor/editor.cmajorpatch
@@ -1,0 +1,17 @@
+{
+    "CmajorVersion":    1,
+    "ID":               "mwriter.vectral",
+    "version":          "1.0",
+    "name":             "Vectral Delay Plugin",
+    "description":      "A delay plugin",
+    "category":         "effect",
+    "manufacturer":     "MWriter",
+    "isInstrument":     false,
+
+    "view":             {
+                            "src": "./index.js",
+                            "width": 500,
+                            "height": 250,
+                            "resizable": false
+                        }
+}

--- a/source/editor/index.js
+++ b/source/editor/index.js
@@ -1,0 +1,93 @@
+
+/*
+    This web component manually creates a set of UI controls for the
+    known parameters, and uses some listeners to connect them to the patch.
+*/
+class VectralView extends HTMLElement
+{
+    constructor (patchConnection)
+    {
+        super();
+        this.patchConnection = patchConnection;
+        this.classList = "vectral-container";
+        this.innerHTML = this.getHTML();
+    }
+
+    connectedCallback()
+    {
+        this.paramListener = (event) =>
+        {
+            // Each of our sliders has the same IDs as an endpoint, so we can find
+            // the HTML element from the endpointID that has changed:
+            const slider = this.querySelector ("#" + event.endpointID);
+
+            if (slider)
+                slider.value = event.value;
+        };
+
+        // Attach a parameter listener that will be triggered when any param is moved
+        this.patchConnection.addAllParameterListener (this.paramListener);
+
+        for (const param of this.querySelectorAll (".param"))
+        {
+            // When one of our sliders is moved, this will send the new value to the patch.
+            param.oninput = () => this.patchConnection.sendEventOrValue (param.id, param.value);
+
+            // for each slider, request an initial update, to make sure it shows the right value
+            this.patchConnection.requestParameterValue (param.id);
+        }
+    }
+
+    disconnectedCallback()
+    {
+        // when our element goes offscreen, we should remove any listeners
+        // from the PatchConnection (which may be shared with other clients)
+        this.patchConnection.removeAllParameterListener (this.paramListener);
+    }
+
+    getHTML()
+    {
+        return `
+        <style>
+            .vectral-container {
+                background: #bcb;
+                display: block;
+                width: 100%;
+                height: 100%;
+                padding: 10px;
+                overflow: auto;
+            }
+
+            .param {
+                display: inline-block;
+                margin: 10px;
+                width: 300px;
+            }
+        </style>
+
+        <div id="controls">
+          <h1>Vectral Delay</h1>
+          <input type="range" class="param" id="mix" min="0" max="24">Mix</input>
+          <input type="range" class="param" id="time" min="0" max="24">Time</input>
+          <input type="range" class="param" id="regen" min="0" max="24">Regen</input>
+          <input type="range" class="param" id="mod" min="0" max="1">Mod</input>
+        </div>`;
+    }
+}
+
+window.customElements.define ("vectral-view", VectralView);
+
+/* This is the function that a host (the command line patch player, or a Cmajor plugin
+   loader, or our VScode extension, etc) will call in order to create a view for your patch.
+
+   Ultimately, a DOM element must be returned to the caller for it to append to its document.
+   However, this function can be `async` if you need to perform asyncronous tasks, such as
+   fetching remote resources for use in the view, before completing.
+
+   When using libraries such as React, this is where the call to `ReactDOM.createRoot` would
+   go, rendering into a container component before returning.
+*/
+export default function createPatchView (patchConnection)
+{
+    return new VectralView (patchConnection);
+}


### PR DESCRIPTION
### Problem

I’d like to craft a pretty UI for Vectral. I don’t want to write the UI in JUCE C++, and I already know JavaScript, HTML, and CSS offers a better facility for UI development.

### Solution

Connect CMajor to the JUCE C++ processor logic to embed a web view and render JavaScript.